### PR TITLE
Auto remove underscore on filter text

### DIFF
--- a/ConeTinue/Domain/TestFilters/FilterOnText.cs
+++ b/ConeTinue/Domain/TestFilters/FilterOnText.cs
@@ -2,7 +2,25 @@ using System.Text.RegularExpressions;
 
 namespace ConeTinue.Domain.TestFilters
 {
-	public class FilterOnText : FilterTests
+    public class FilterOnTextWithReplaceUnderscore : FilterTests
+    {
+        private readonly FilterOnText filterOnText;
+
+		public FilterOnTextWithReplaceUnderscore(FilterOnText filterOnText) : base(FilterType.FilterOnText)
+		{
+			this.filterOnText = filterOnText;
+			if (!string.IsNullOrEmpty(filterOnText.Filter))
+				filterOnText.Filter = filterOnText.Filter.Replace("_", " ");
+		}
+
+        public string Filter => filterOnText.Filter;
+
+        public override void Apply(TestItemHolder testItemHolder) => filterOnText.Apply(testItemHolder);
+
+        public override string ToString() => filterOnText.ToString();
+    }
+
+    public class FilterOnText : FilterTests
 	{
 		private readonly bool showWhenMatching;
 

--- a/ConeTinue/ViewModels/FilterViewModel.cs
+++ b/ConeTinue/ViewModels/FilterViewModel.cs
@@ -41,7 +41,7 @@ namespace ConeTinue.ViewModels
 
 		public bool CanContinueFilterTests
 		{
-			get {return filter.Length != 0; }
+			get { return filter.Length != 0; }
 		}
 
 		public bool CanNewFilterTests
@@ -49,7 +49,7 @@ namespace ConeTinue.ViewModels
 			get { return filter.Length != 0; }
 		}
 
-		
+
 		public void ContinueFilterTests()
 		{
 			FilterTests();
@@ -57,7 +57,7 @@ namespace ConeTinue.ViewModels
 
 		public void FilterTests()
 		{
-			eventAggregator.Publish(new FilterOnText(Filter, ShowWhenMatching));
+			eventAggregator.Publish(new FilterOnTextWithReplaceUnderscore(new FilterOnText(Filter, ShowWhenMatching)));
 			Filter = string.Empty;
 		}
 


### PR DESCRIPTION
Added an wrapper for FilterOnText,, the wrapper removes underscore (_) so a copied method name (test) could be pasted and used to filter on.